### PR TITLE
fix(frontend): case sensitive mistake in Settings.tsx

### DIFF
--- a/frontend/src/components/Settings/Settings.tsx
+++ b/frontend/src/components/Settings/Settings.tsx
@@ -8,7 +8,7 @@ import {
   Button,
 } from "@aws-amplify/ui-react";
 
-import cache from "../../helpers/Cache";
+import cache from "../../helpers/cache";
 
 type SettingsProps = {
   children?: React.ReactNode;


### PR DESCRIPTION
Build failing on own C9:

```
Admin:~/environment/aws-lambda-powertools-typescript-workshop (main) $ npm run frontend:build

> aws-lambda-powertools-typescript-workshop@1.0.0 frontend:build
> npm run build -w frontend


> frontend@0.0.0 build
> tsc && vite build

src/components/Settings/Settings.tsx:11:19 - error TS2307: Cannot find module '../../helpers/Cache' or its corresponding type declarations.

11 import cache from "../../helpers/Cache";
                     ~~~~~~~~~~~~~~~~~~~~~


Found 1 error in src/components/Settings/Settings.tsx:11

npm ERR! Lifecycle script `build` failed with error: 
npm ERR! Error: command failed 
npm ERR!   in workspace: frontend@0.0.0 
npm ERR!   at location: /home/ec2-user/environment/aws-lambda-powertools-typescript-workshop/frontend 
```


Code might have been built on none case sensitive file system such as OSX one . 

*Description of changes:*
Just fix wrong Caps letter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
