### PR TITLE
chore(infra): update Python runtime in functions

### DIFF
--- a/infra/lib/image-detection/functions-construct.ts
+++ b/infra/lib/image-detection/functions-construct.ts
@@ -61,7 +61,7 @@ export class FunctionsConstruct extends Construct {
         entry: '../functions/python/modules/module2/',
         functionName,
         index: 'app.py',
-        runtime: Runtime.PYTHON_3_11,
+        runtime: Runtime.PYTHON_3_12,
         handler: 'lambda_handler',
         environment: {
           ...localEnvVars,

--- a/infra/lib/reporting-service/functions-construct.ts
+++ b/infra/lib/reporting-service/functions-construct.ts
@@ -57,7 +57,7 @@ export class FunctionsConstruct extends Construct {
         entry: '../functions/python/modules/module2/',
         functionName,
         index: 'app.py',
-        runtime: Runtime.PYTHON_3_11,
+        runtime: Runtime.PYTHON_3_12,
         handler: 'lambda_handler',
         environment: {
           ...localEnvVars,

--- a/infra/lib/thumbnail-generator/functions-construct.ts
+++ b/infra/lib/thumbnail-generator/functions-construct.ts
@@ -63,7 +63,7 @@ export class FunctionsConstruct extends Construct {
         entry: '../functions/python/modules/module1/',
         functionName,
         index: 'app.py',
-        runtime: Runtime.PYTHON_3_11,
+        runtime: Runtime.PYTHON_3_12,
         handler: 'lambda_handler',
         environment: {
           ...localEnvVars,


### PR DESCRIPTION
*Issue #, if available:* #50

*Description of changes:*

This PR updates the runtime for the Python function from `PYTHON_3_11` to `PYTHON_3_12`.

I have confirmed that the `cdk_nag` have gone away by running `npm run infra:synth`, which tells CDK to synth the infra and run CDK NAG.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
