### PR TITLE
chore (API): Specify version in VSCode installation command

### DIFF
--- a/api-workshop/lib/attendant-ide/compute-construct.ts
+++ b/api-workshop/lib/attendant-ide/compute-construct.ts
@@ -129,7 +129,7 @@ export class ComputeConstruct extends Construct {
       ),
       // Install & configure VSCode
       this.#runCommandAsWhoamiUser(
-        'curl -fsSL https://code-server.dev/install.sh | sh',
+        'curl -fsSL https://code-server.dev/install.sh | sh -s -- --version=4.104.3',
         'code-server --install-extension ms-python.python'
       ),
       // Configure VSCode preferences


### PR DESCRIPTION
API workshop, disable the `build with agent` sidebar, which in the new vscode build it is not possible to hide due to an upstream bug https://github.com/coder/code-server/issues/7540


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
