### PR TITLE
chore: update the aws cli arch to x86_64 architecture in the API workshop

### DIFF
--- a/api-workshop/lib/attendant-ide/compute-construct.ts
+++ b/api-workshop/lib/attendant-ide/compute-construct.ts
@@ -111,7 +111,7 @@ export class ComputeConstruct extends Construct {
       ),
       // Install AWS CLI
       this.#runCommandAsWhoamiUser(
-        'curl https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip -o $HOME/awscliv2.zip',
+        'curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o $HOME/awscliv2.zip',
         'unzip $HOME/awscliv2.zip',
         'sudo $HOME/aws/install',
         'rm -rf $HOME/awscliv2.zip $HOME/aws',


### PR DESCRIPTION
*Description of changes:*

This PR changes the architecture of the AWS CLI that's downloaded and installed on the instance used by the attendant IDE. The machine image is x86_64 but the AWS CLI was downloading the incorrect architecture installer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
